### PR TITLE
Fixes #9: Better wheel implementation provides 4x speedup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,15 +87,6 @@ pub struct TrialDivision {
     lst: Vec<u64>,
 }
 
-const FIRST_PRIMES: [u64; 4] = [2, 3, 5, 7];
-const WHEEL_LENGTH: usize = 48;
-const WHEEL_CIRCUMFERENCE: u64 = WHEEL_2357[WHEEL_LENGTH - 1] + 1;
-const WHEEL_2357: [u64; WHEEL_LENGTH] = [
-    1, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101,
-    103, 107, 109, 113, 121, 127, 131, 137, 139, 143, 149, 151, 157, 163, 167, 169, 173, 179, 181,
-    187, 191, 193, 197, 199, 209,
-];
-
 /*
 A factorization wheel that enables iteration over all positive integers that are coprime with
 all of the primes in `FIRST_PRIMES`.
@@ -129,6 +120,15 @@ pub struct PrimeSetIter<'a, P: PrimeSet> {
 }
 
 impl Wheel {
+    const FIRST_PRIMES: [u64; 4] = [2, 3, 5, 7];
+    const BASE_LENGTH: usize = 48;
+    const CIRCUMFERENCE: u64 = Self::BASE[Self::BASE_LENGTH - 1] + 1;
+    const BASE: [u64; Self::BASE_LENGTH] = [
+        1, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101,
+        103, 107, 109, 113, 121, 127, 131, 137, 139, 143, 149, 151, 157, 163, 167, 169, 173, 179,
+        181, 187, 191, 193, 197, 199, 209,
+    ];
+
     fn new() -> Self {
         Self {
             offset: 0,
@@ -149,14 +149,14 @@ impl Iterator for Wheel {
     type Item = u64;
 
     fn next(&mut self) -> Option<u64> {
-        if self.index + 1 >= WHEEL_LENGTH {
+        if self.index + 1 >= Self::BASE_LENGTH {
             self.index = 0;
-            self.offset += WHEEL_CIRCUMFERENCE;
+            self.offset += Self::CIRCUMFERENCE;
         } else {
             self.index += 1;
         }
 
-        self.value = self.factor * (self.offset + WHEEL_2357[self.index]);
+        self.value = self.factor * (self.offset + Self::BASE[self.index]);
         Some(self.value)
     }
 }
@@ -232,7 +232,7 @@ impl Sieve {
     /// A new prime generator, primed with 2 and 3
     pub fn new() -> Self {
         Self {
-            primes: FIRST_PRIMES.to_vec(),
+            primes: Wheel::FIRST_PRIMES.to_vec(),
             sieve: BinaryHeap::new(),
             wheel: Wheel::new(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,10 +87,14 @@ pub struct TrialDivision {
     lst: Vec<u64>,
 }
 
-const FIRST_PRIMES: [u64; 3] = [2, 3, 5];
-const WHEEL_LENGTH: usize = 8;
-const WHEEL_CIRCUMFERENCE: u64 = WHEEL_235[WHEEL_LENGTH - 1] + 1;
-const WHEEL_235: [u64; WHEEL_LENGTH] = [1, 7, 11, 13, 17, 19, 23, 29];
+const FIRST_PRIMES: [u64; 4] = [2, 3, 5, 7];
+const WHEEL_LENGTH: usize = 48;
+const WHEEL_CIRCUMFERENCE: u64 = WHEEL_2357[WHEEL_LENGTH - 1] + 1;
+const WHEEL_2357: [u64; WHEEL_LENGTH] = [
+    1, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101,
+    103, 107, 109, 113, 121, 127, 131, 137, 139, 143, 149, 151, 157, 163, 167, 169, 173, 179, 181,
+    187, 191, 193, 197, 199, 209,
+];
 
 #[derive(Debug, Clone, Copy)]
 struct Wheel {
@@ -156,7 +160,7 @@ impl Iterator for Wheel {
             self.index += 1;
         }
 
-        self.value = self.factor * (self.offset + WHEEL_235[self.index]);
+        self.value = self.factor * (self.offset + WHEEL_2357[self.index]);
         Some(self.value)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ A prime generator, using the Trial Division method.
 
 Create with `let mut pset = TrialDivision::new()`, and then use `pset.iter()` to iterate over all
 primes.
-**/
+*/
 #[derive(Clone)]
 pub struct TrialDivision {
     lst: Vec<u64>,
@@ -96,6 +96,10 @@ const WHEEL_2357: [u64; WHEEL_LENGTH] = [
     187, 191, 193, 197, 199, 209,
 ];
 
+/*
+A factorization wheel that enables iteration over all positive integers that are coprime with
+all of the primes in `FIRST_PRIMES`.
+*/
 #[derive(Debug, Clone, Copy)]
 struct Wheel {
     offset: u64,
@@ -105,22 +109,14 @@ struct Wheel {
 }
 
 /**
-A prime generator, using the Sieve of Eratosthenes method. This is asymptotically more efficient
-than the Trial Division method, but slower earlier on.
+A prime generator, using the Sieve of Eratosthenes method.
 
 Create with `let mut pset = Sieve::new()`, and then use `pset.iter()` to iterate over all primes.
-**/
+*/
 #[derive(Clone)]
 pub struct Sieve {
     primes: Vec<u64>,
     wheel: Wheel,
-
-    // Keys are composites, values are prime factors.
-    //
-    // Every prime is in here once.
-    //
-    // Each entry corresponds to the last composite "crossed off" by the given prime,
-    // not including any composite less than the values in 'primes'.
     sieve: BinaryHeap<Reverse<Wheel>>,
 }
 


### PR DESCRIPTION
[Fixes #9]

This PR includes the changes to the `Wheel` type that I recommended in issue #9.

The graphs below show the  performance of the `Sieve` and `TrialDivision` prime generators. No changes have been made to `TrialDivision`, so the green line in all of these graphs is the same. 

First, here is the performance of the prime generators without the changes I'm recommending. Notice that the line for `Sieve` is well above the line for `TrialDivision` (lower is better). In fact, `TrialDivision` is usually twice as fast as `Sieve`.

![image](https://github.com/user-attachments/assets/93e6c564-670b-4ec3-ab92-d8eeaa8a128b)

Just by implementing the `peek_mut()` optimization I suggested in issue #9, we double the speed of `Sieve`. It's now slightly faster than `TrialDivision` no matter the input size.

![image](https://github.com/user-attachments/assets/b7876001-3fe9-4873-bec7-124ebfc9ea54)

Then, using the improved `Wheel` implementation, we get another doubling. The `Sieve` is now *much* faster than `TrialDivision` for all input sizes.

![image](https://github.com/user-attachments/assets/9d03861c-113b-441f-9430-094d8a757ca9)